### PR TITLE
Support the hostnamelookups directive.

### DIFF
--- a/files/metaconfig/httpd/vhost.tt
+++ b/files/metaconfig/httpd/vhost.tt
@@ -22,3 +22,7 @@ documentroot [% vhost.DocumentRoot %]
 [%- IF vhost.exists('rewrite') -%]
 [% INCLUDE metaconfig/httpd/rewrite.tt desc=vhost.rewrite %]
 [%- END -%]
+
+[%- IF vhost.exists('hostname_lookups') -%]
+hostnamelookups [% vhost.hostname_lookups ? "on" : "off" %]
+[%- END -%]


### PR DESCRIPTION
Needed to configure securely a Quattor server.
